### PR TITLE
adding author profile

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -10,6 +10,21 @@ Tam H:
       url: https://github.com/exposit
       icon: fab fa-github-square
 
+Luke M:
+  name: Luke M
+  picture: /images/bio-photo-alt.jpg
+  discord: "Luke#8284"
+  links:
+    - title: Github
+      url: https://github.com/mootootwo
+      icon: fab fa-github-square
+    - title: Twitter
+      url: https://twitter.com/mootootwo
+#      icon: fab fa-github-square
+    - title: Blogger
+      url: https://ktsink.blogspot.com/
+#      icon: fab fa-github-square  
+      
 # Cornelius Fiddlebone:
 #   name: Cornelius Fiddlebone
 #   picture: /images/bio-photo.jpg


### PR DESCRIPTION
not sure how the icons work.  couldn't find an example of the fa-github-square as an image anywhere in the repo.  Looking at the running page, it seems to be rendered inline.

I can get icons for blogger and twitter, but where can I find the correct size / format and where to put the images?